### PR TITLE
how to fix mount namespace separation setting in SuperSU might not work ...

### DIFF
--- a/supersu
+++ b/supersu
@@ -1,0 +1,1 @@
+how to fix mount namespace separation setting in SuperSU might not work reliably on some platform


### PR DESCRIPTION
...reliably on some platform

how to fix mount namespace separation setting in SuperSU might not work reliably on some platform