### PR TITLE
Proper SELinux state detection

### DIFF
--- a/libsuperuser/src/eu/chainfire/libsuperuser/Shell.java
+++ b/libsuperuser/src/eu/chainfire/libsuperuser/Shell.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -489,9 +490,16 @@ public class Shell {
                         }
                     }
 
-                    // 4.4+ builds are enforcing by default, take the gamble
+                    // 4.4+ has a new API to detect SELinux mode, so use it
+                    // SELinux is typically in enforced mode, but emulators may have SELinux disabled
                     if (enforcing == null) {
-                        enforcing = (android.os.Build.VERSION.SDK_INT >= 19);
+                        try {
+                            Class seLinux = Class.forName("android.os.SELinux");
+                            Method isSELinuxEnforced = seLinux.getMethod("isSELinuxEnforced");
+                            enforcing = (boolean) isSELinuxEnforced.invoke(seLinux.newInstance());
+                        } catch (Exception e) {
+                            enforcing = false;
+                        }
                     }
                 }
 

--- a/libsuperuser/src/eu/chainfire/libsuperuser/Shell.java
+++ b/libsuperuser/src/eu/chainfire/libsuperuser/Shell.java
@@ -498,7 +498,8 @@ public class Shell {
                             Method isSELinuxEnforced = seLinux.getMethod("isSELinuxEnforced");
                             enforcing = (boolean) isSELinuxEnforced.invoke(seLinux.newInstance());
                         } catch (Exception e) {
-                            enforcing = false;
+                            // 4.4+ release builds are enforcing by default, take the gamble
+                            enforcing = (android.os.Build.VERSION.SDK_INT >= 19);
                         }
                     }
                 }


### PR DESCRIPTION
@chainfire
I am working on app which patches sepolicies but it seems that lib has been incorrectly (well, it failed anyway) patching SELinux policies on Genymotion emulator and it fails with selinux/policy file not found since it llibrary expects that everything 4,4+ is enforced. (emulator has selinux disabled).

So use Android (hidden) API to check SELinux state and detect it properly.