### PR TITLE
Enable basic GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - uses: gradle/wrapper-validation-action@v1
+      - run: ./gradlew build

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# librootjava
+
+[![ci][1]][2]
+
 Example code for "How-To SU"
 
 For some outdated background details, see:
@@ -418,3 +422,6 @@ dependencies {
     implementation 'eu.chainfire:libsuperuser:1.0.0.+'
 }
 ```
+
+[1]: https://github.com/Chainfire/libsuperuser/workflows/ci/badge.svg
+[2]: https://github.com/Chainfire/libsuperuser/actions

--- a/libsuperuser/build.gradle
+++ b/libsuperuser/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdkVersion 5
         targetSdkVersion 26
     }
-    
+
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
@@ -32,7 +32,9 @@ group = "eu.chainfire"
 
 bintray {
     Properties properties = new Properties()
-    properties.load(project.rootProject.file('local.properties').newDataInputStream())
+    if (project.rootProject.file('local.properties').exists()) {
+        properties.load(project.rootProject.file('local.properties').newDataInputStream())
+    }
     user = properties.getProperty('bintray.user')
     key = properties.getProperty('bintray.apikey')
 


### PR DESCRIPTION
This enables a basic CI using [GitHub Actions](https://github.com/features/actions).

Currently it does the following:

- Clones the code and sets up the environment (JDK8)
- Validates the `gradle-wrapper.jar` binary (to prevent malicious code)
- Runs `./gradlew build` (which will also run the `test` task)

This also adds a badge showing CI status to README.md:

![ci][1]

Supersedes and closes #83 

[1]: https://github.com/friederbluemle/libsuperuser/workflows/ci/badge.svg
